### PR TITLE
service input validation and error message in html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ report.html
 output.xml
 selenium-screenshot-1.png
 .coverage*
+selenium-screenshot*

--- a/bibtex_generator/repositories/citation_repository.py
+++ b/bibtex_generator/repositories/citation_repository.py
@@ -7,14 +7,14 @@ class CitationRepository:
         self._citation = Citation()
         self._db = db
 
-    def insert_citation(self, citation_name, title, year, author):
+    def insert_citation(self, citation_object):
         sql = """INSERT INTO citations (citation_name, title, year, author)
                  VALUES (:citation_name, :title, :year, :author)"""
         self._db.session.execute(sql, {
-            "citation_name": citation_name,
-            "title": title,
-            "year": year,
-            "author": author
+            "citation_name": citation_object.citation_name,
+            "title": citation_object.title,
+            "year": citation_object.year,
+            "author": citation_object.author
         }
         )
         self._db.session.commit()

--- a/bibtex_generator/routes.py
+++ b/bibtex_generator/routes.py
@@ -1,7 +1,8 @@
 from flask import render_template, request, redirect, abort, session
 from app import app
 from db import db
-from services.citation_service import CitationService
+from entities import Citation
+from services.citation_service import CitationService, WrongAttributeTypeError
 from repositories.citation_repository import CitationRepository
 
 citation_service = CitationService(CitationRepository(db))
@@ -25,23 +26,29 @@ def citations():
 @app.route("/new_citation", methods=["GET", "POST"])
 def new_citation():
     if request.method == "GET":
-        return render_template("new_citation.html")
+        return render_template("new_citation.html", citation = False)
 
     if request.method == "POST":
-        citation_name = request.form["citation_name"]
-        title = request.form["title"]
-        year = request.form["year"]
-        author = request.form["author"]
-
-        citation_service.create_citation(
-            citation_name, title, year, author)
-
-        return redirect_to_new_citation()
-
+        print(request.form["year"])
+        citation_object = Citation(
+            citation_name = request.form["citation_name"],
+            title = request.form["title"],
+            year = request.form["year"],
+            author = request.form["author"]
+        )
+        try:
+            citation_service.create_citation(citation_object)
+            return redirect_to_new_citation()
+        except WrongAttributeTypeError as error:
+            return render_template(
+                "new_citation.html",
+                error_message = "Wrong types for: " + str(error)
+            )
 
 @app.route("/citations/<int:id>")
 def citation(id):
     citation = citation_service.get_citation(id)
+    print(citation)
     return render_template("citation.html", id=id, citation=citation)
 
 @app.route("/search")

--- a/bibtex_generator/services/citation_service.py
+++ b/bibtex_generator/services/citation_service.py
@@ -1,10 +1,43 @@
+class WrongAttributeTypeError(Exception):
+    pass
+
 class CitationService:
     def __init__(self, citation_repository):
         self._citation_repository = citation_repository
+        self.attribute_types = {
+            "citation_name" : str,
+            "type" : str,
+            "author" : str,
+            "title" : str,
+            "booktitle" : str,
+            "series" : str,
+            "publisher" : str,
+            "school" : str,
+            "address" : str,
+            "journal" : str,
+            "howpublished" : str,
+            "year" : int,
+            "month" : str,
+            "volume" : str,
+            "number" : int,
+            "pages" : str,
+            "note" : str
+        }
 
-    def create_citation(self, citation_name, title, year, author):
-        self._citation_repository.insert_citation(
-            citation_name, title, year, author)
+    def create_citation(self, citation_object):
+        errors = self.validate_citation(citation_object)
+        if errors:
+            raise WrongAttributeTypeError(*errors)
+        self._citation_repository.insert_citation(citation_object)
+
+    def validate_citation(self, citation):
+        errors = []
+        for key, value in citation.get_data().items():
+            try:
+                setattr(citation, key, self.attribute_types[key](value))
+            except ValueError:
+                errors.append(key)
+        return errors
 
     def get_citation(self, id):
         return self._citation_repository.get_citation(id)

--- a/bibtex_generator/templates/new_citation.html
+++ b/bibtex_generator/templates/new_citation.html
@@ -2,14 +2,18 @@
 {% block title %}New citation{% endblock %}
 {% block content %}
 <h2>Create new citation</h2>
+{% if error_message %}
+    <p class=error><strong>Error:</strong> {{ error_message }}
+{% endif %}
 <form action="/new_citation" method="POST">
-Citation name: <br><input type="text" name="citation_name">
+
+Citation name: <br><input type="text" name="citation_name" value = {{request.form.citation_name}}>
 <p>
-Title: <br><input type="text" name="title">
+Title: <br><input type="text" name="title" value = {{request.form.title}}>
 <p>
-Year: <br><input type="text" name="year">
+Year: <br><input type="text" name="year" value = {{request.form.year}}>
 <p>
-Author: <br><input type="text" name="author">
+Author: <br><input type="text" name="author" value = {{request.form.author}}>
 <p>
 <input type="submit" value="Create new">
 </form>

--- a/bibtex_generator/tests/citation_service_test.py
+++ b/bibtex_generator/tests/citation_service_test.py
@@ -1,27 +1,36 @@
 import unittest
 from unittest.mock import Mock
 from services.citation_service import CitationService
+from services.citation_service import WrongAttributeTypeError
 
 
 class TestCitationService(unittest.TestCase):
     def setUp(self):
         self.citation_repository_mock = Mock()
         self.citation_service = CitationService(self.citation_repository_mock)
+        self.citation = Mock()
+        self.citation.citation_name = "test"
+        self.citation.title = "testi kirja"
+        self.citation.year = 2022
+        self.citation.author = "testaaja"
+        def returns():
+            return {
+                "citation_name" : self.citation.citation_name,
+                "title" : self.citation.title, 
+                "year" : self.citation.year,
+                "author" : self.citation.author
+            }
+        self.citation.get_data.side_effect = returns
 
     def test_can_add_citation(self):
-        self.citation_service.create_citation(
-            "testi", "testi kirja", 2022, "testaaja")
+        self.citation_service.create_citation(self.citation)
 
-        self.citation_repository_mock.insert_citation.assert_called_with(
-            "testi", "testi kirja", 2022, "testaaja")
+        self.citation_repository_mock.insert_citation.assert_called_with(self.citation)
 
     def test_can_add_multiple_citations(self):
-        self.citation_service.create_citation(
-            "testi", "testi kirja", 2022, "testaaja")
-        self.citation_service.create_citation(
-            "testi2", "testi kirja", 2022, "testaaja")
-        self.citation_service.create_citation(
-            "testi3", "testi kirja", 2022, "testaaja")
+        self.citation_service.create_citation(self.citation)
+        self.citation_service.create_citation(self.citation)
+        self.citation_service.create_citation(self.citation)
 
         self.assertEqual(
             self.citation_repository_mock.insert_citation.call_count, 3)
@@ -39,3 +48,15 @@ class TestCitationService(unittest.TestCase):
         citations = self.citation_service.get_citations()
         print(citations)
         self.assertEqual(len(citations), 2)
+    
+    def test_citation_validation_returns_an_empty_list_when_correct_attribute_type_is_used(self):
+        self.assertEqual(self.citation_service.validate_citation(self.citation), [])
+
+    def test_citation_validation_returns_a_non_empty_list_when_wrong_attribute_type_is_used(self):
+        self.citation.year = "test"
+        self.assertEqual(type(self.citation_service.validate_citation(self.citation)), list)
+        self.assertTrue(len(self.citation_service.validate_citation(self.citation)) > 0)
+
+    def test_create_citation_raises_typeerror_when_wrong_attribute_type_is_used(self):
+        self.citation.year = "test"
+        self.assertRaises(WrongAttributeTypeError, self.citation_service.create_citation, self.citation)

--- a/bibtex_generator/tests/new_citation.robot
+++ b/bibtex_generator/tests/new_citation.robot
@@ -26,4 +26,12 @@ View New Citation
     Page Should Contain  author = "robot testaaja"
     Page Should Contain  title = "test2"
     Page Should Contain  year = "2022"
-    
+
+Add Incorrect Citation
+    Go To New Citation Page
+    Input Text  citation_name  robottest
+    Input Text  title  test
+    Input Text  year  test year
+    Input Text  author  robot testaaja
+    Click Button  Create new
+    Page Should Contain  Error


### PR DESCRIPTION
- The CitationService now tries turning the attributes into respective types. If it fails a WrongAttributeTypeError is raised.  

- An error message is displayed on the new_citation page containing info about which attributes are wrong type.  

- The Citation class has been implemented to make it easier to test the CitationService class. 