### PR TITLE
Add bibtex_formatter for automatic BibTeX conversion

### DIFF
--- a/bibtex_generator/entities/bibtex_formatter.py
+++ b/bibtex_generator/entities/bibtex_formatter.py
@@ -3,7 +3,7 @@ from pylatexenc.latexencode import unicode_to_latex
 from entities.citation import Citation
 
 def create_bibtex_citation(citation):
-    if type(citation) is Citation:
+    if isinstance(citation, Citation):
         citation = citation.get_data()
     type_key = "type"
     name_key = "citation_name"

--- a/bibtex_generator/entities/bibtex_formatter.py
+++ b/bibtex_generator/entities/bibtex_formatter.py
@@ -1,0 +1,17 @@
+from pylatexenc.latexencode import unicode_to_latex
+import html
+
+def create_bibtex_citation(citation):
+    bibtex_string = f"@{citation.type}{{{citation.citation_name}\n"
+    for key in citation.keys():
+        if key != "id" and key != "citation_name" and key != "type" and citation[key]:
+            bibtex_string += f"\t{key}: \"{unicode_to_latex(citation[key])}\"\n"
+    bibtex_string += "}"
+
+    return bibtex_string
+
+def create_bibtex_citation_html(citation):
+    bibtex_string = create_bibtex_citation(citation)
+    bibtex_string = html.escape(bibtex_string)
+    bibtex_string = bibtex_string.replace("\n", "<br>").replace("\t", "&emsp;&emsp;")
+    return bibtex_string

--- a/bibtex_generator/entities/bibtex_formatter.py
+++ b/bibtex_generator/entities/bibtex_formatter.py
@@ -1,8 +1,13 @@
 import html
 from pylatexenc.latexencode import unicode_to_latex
+from entities.citation import Citation
 
 def create_bibtex_citation(citation):
-    bibtex_string = f"@{citation.type}{{{citation.citation_name}\n"
+    if type(citation) is Citation:
+        citation = citation.get_data()
+    type_key = "type"
+    name_key = "citation_name"
+    bibtex_string = f"@{citation[type_key]}{{{citation[name_key]}\n"
     for key in citation.keys():
         if key != "id" and key != "citation_name" and key != "type" and citation[key]:
             bibtex_string += f"\t{key}: \"{unicode_to_latex(citation[key])}\"\n"

--- a/bibtex_generator/entities/bibtex_formatter.py
+++ b/bibtex_generator/entities/bibtex_formatter.py
@@ -1,5 +1,5 @@
-from pylatexenc.latexencode import unicode_to_latex
 import html
+from pylatexenc.latexencode import unicode_to_latex
 
 def create_bibtex_citation(citation):
     bibtex_string = f"@{citation.type}{{{citation.citation_name}\n"

--- a/bibtex_generator/repositories/citation_repository.py
+++ b/bibtex_generator/repositories/citation_repository.py
@@ -8,10 +8,11 @@ class CitationRepository:
         self._db = db
 
     def insert_citation(self, citation_object):
-        sql = """INSERT INTO citations (citation_name, title, year, author)
-                 VALUES (:citation_name, :title, :year, :author)"""
+        sql = """INSERT INTO citations (citation_name, type, title, year, author)
+                 VALUES (:citation_name, :type, :title, :year, :author)"""
         self._db.session.execute(sql, {
             "citation_name": citation_object.citation_name,
+            "type": citation_object.type,
             "title": citation_object.title,
             "year": citation_object.year,
             "author": citation_object.author
@@ -20,21 +21,20 @@ class CitationRepository:
         self._db.session.commit()
 
     def get_citation(self, id):
-        sql = "SELECT id, citation_name, title, year, author FROM citations WHERE id=:id"
+        sql = "SELECT * FROM citations WHERE id=:id"
         result = self._db.session.execute(sql, {"id": id})
         citation = result.fetchone()
         return citation
 
     def get_citations(self):
-        result = self._db.session.execute("""SELECT id, citation_name, title, year, author
-                                             FROM citations""")
+        result = self._db.session.execute("""SELECT * FROM citations""")
         citations = result.fetchall()
         return citations
 
     def citation_search(self):
         prequery = request.args["query"]
         query = prequery.lower()
-        sql = "SELECT id, citation_name, type, title, year, author FROM citations " \
+        sql = "SELECT * FROM citations " \
               "WHERE lower(citation_name) LIKE :query or lower(type) LIKE :query"
         result = db.session.execute(sql, {"query": "%" + query + "%"})
         citations = result.fetchall()

--- a/bibtex_generator/routes.py
+++ b/bibtex_generator/routes.py
@@ -32,6 +32,7 @@ def new_citation():
         print(request.form["year"])
         citation_object = Citation(
             citation_name = request.form["citation_name"],
+            type = "book",
             title = request.form["title"],
             year = request.form["year"],
             author = request.form["author"]

--- a/bibtex_generator/routes.py
+++ b/bibtex_generator/routes.py
@@ -4,6 +4,7 @@ from db import db
 from entities import Citation
 from services.citation_service import CitationService, WrongAttributeTypeError
 from repositories.citation_repository import CitationRepository
+from entities.bibtex_formatter import create_bibtex_citation_html
 
 citation_service = CitationService(CitationRepository(db))
 
@@ -49,8 +50,8 @@ def new_citation():
 @app.route("/citations/<int:id>")
 def citation(id):
     citation = citation_service.get_citation(id)
-    print(citation)
-    return render_template("citation.html", id=id, citation=citation)
+    bibtex_string = create_bibtex_citation_html(citation)
+    return render_template("citation.html", id=id, citation=citation, bibtex_string=bibtex_string)
 
 @app.route("/search")
 def result():

--- a/bibtex_generator/routes.py
+++ b/bibtex_generator/routes.py
@@ -2,9 +2,9 @@ from flask import render_template, request, redirect, abort, session
 from app import app
 from db import db
 from entities import Citation
+from entities.bibtex_formatter import create_bibtex_citation_html
 from services.citation_service import CitationService, WrongAttributeTypeError
 from repositories.citation_repository import CitationRepository
-from entities.bibtex_formatter import create_bibtex_citation_html
 
 citation_service = CitationService(CitationRepository(db))
 

--- a/bibtex_generator/templates/citation.html
+++ b/bibtex_generator/templates/citation.html
@@ -6,19 +6,12 @@
 <h3>Latex-form:</h3>
 <p>
     [{{citation.id}}] {{citation.author}}, <i> {{citation.title}} </i>, {{citation.year}}
+</p>
 <p>
     <h3>Bibtex-form:</h3>
-  @book{ {{citation.citation_name}},
-<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; author = "{{citation.author}}",
-<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; title = "{{citation.title}}",
-<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; year = "{{citation.year}}",
-<br>
-    }
-<br>
-<br>
+    {{bibtex_string|safe}}
+    <br>
+</p>
 <a href="/citations">Return</a>
 
 

--- a/bibtex_generator/tests/bibtex_formatter_test.py
+++ b/bibtex_generator/tests/bibtex_formatter_test.py
@@ -1,0 +1,33 @@
+import unittest
+from entities.bibtex_formatter import create_bibtex_citation, create_bibtex_citation_html
+from entities.citation import Citation
+
+class TestBibtexFromatter(unittest.TestCase):
+    def setUp(self):
+        self.citation_object = Citation(
+            citation_name = "Test22",
+            type = "book",
+            author = "TestAuthor",
+            title = "TestBook",
+            year = 2022
+        )
+        self.correct_string = ("@book{Test22\n"
+            "\tauthor: \"TestAuthor\"\n"
+            "\ttitle: \"TestBook\"\n"
+            "\tyear: \"2022\"\n"
+            "}"
+        )
+        self.correct_string_html = ("@book{Test22<br>"
+        "&emsp;&emsp;author: &quot;TestAuthor&quot;<br>"
+        "&emsp;&emsp;title: &quot;TestBook&quot;<br>"
+        "&emsp;&emsp;year: &quot;2022&quot;<br>"
+        "}"
+        )
+    
+    def test_create_bibtex_citation_works(self):
+        bibtex_string = create_bibtex_citation(self.citation_object)
+        self.assertEqual(bibtex_string, self.correct_string)
+    
+    def test_create_bibtex_citation_html_works(self):
+        bibtex_string_html = create_bibtex_citation_html(self.citation_object)
+        self.assertEqual(bibtex_string_html, self.correct_string_html)

--- a/poetry.lock
+++ b/poetry.lock
@@ -384,6 +384,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pylatexenc"
+version = "2.10"
+description = "Simple LaTeX parser providing latex-to-unicode and unicode-to-latex conversion"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pylint"
 version = "2.15.7"
 description = "python code static checker"
@@ -692,7 +700,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c5de0c8eaf8f9e981c24780a3c30ce76ebba6afd02f0709493404a97b63a82b8"
+content-hash = "a9a41594eb5b70e6b5e9794fe668537f0093344719756a106e7fe63e35ae681f"
 
 [metadata.files]
 astroid = [
@@ -1140,6 +1148,9 @@ pycodestyle = [
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+pylatexenc = [
+    {file = "pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3"},
 ]
 pylint = [
     {file = "pylint-2.15.7-py3-none-any.whl", hash = "sha256:1d561d1d3e8be9dd880edc685162fbdaa0409c88b9b7400873c0cf345602e326"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ pytest = "^7.2.0"
 requests = "^2.28.1"
 robotframework = "^6.0.1"
 robotframework-seleniumlibrary = "^6.0.0"
+pylatexenc = "^2.10"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
New function create_bibtex_citation(citation) returns a string of the citation in its BibTeX-form, automatically converting text to a LaTeX-friendly form. As an argument accepts a Citation object of any type, or an SQLAlchemy Row-object (which is what CitationService.get_sitation() currently returns).

Function create_bibtex_citation_html(citation) returns the same thing, except in html form.